### PR TITLE
Debian rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Antonio Radici <antonio@debian.org>
 Build-Depends: debhelper (>= 7.0.50), autotools-dev, libssl-dev,
  flex, bison, libpcre3-dev, dh-autoreconf,  libtokyocabinet-dev, libvirt-dev, libacl1-dev,
-  libmysqlclient-dev, libpq-dev
+  libmysqlclient-dev, libpq-dev, libxml2.dev
 Standards-Version: 3.9.3
 Homepage: http://www.cfengine.org/
 Vcs-Browser: http://git.debian.org/?p=collab-maint/cfengine3.git

--- a/debian/rules
+++ b/debian/rules
@@ -7,10 +7,8 @@
 override_dh_auto_configure:
 	dh_autoreconf
 	./configure --enable-shared=no \
-				--without-nova \
-				--without-constellation \
 				--prefix=/usr \
-				--with-sql=no \
+				--with-sql=yes \
 				--with-workdir=/var/lib/cfengine3 \
 				--mandir=\$${prefix}/share/man \
 				--infodir=\$${prefix}/share/info \

--- a/debian/source/local-options
+++ b/debian/source/local-options
@@ -1,1 +1,1 @@
-unapply-patches
+#unapply-patches


### PR DESCRIPTION
Compile options:

```
--without-nova \
--without-constellation generate errors in the log and are no longer valid.
```

Changed --with-mysql to yes

Commented out unapply patches in debian/local-options
